### PR TITLE
Feat: Expose skip_jre_provisioning input, default false

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,20 +194,36 @@ For information on the build wrapper for C language based projects:
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name         | Required | Default                             | Description                                            |
-| --------------------- | -------- | ----------------------------------- | ------------------------------------------------------ |
-| sonar_token           | True     | N/A                                 | Mandatory authentication token to upload results       |
-| sonar_root_cert       | False    | N/A                                 | PEM encoded server root certificate (for HTTPS upload) |
-| build_wrapper_url     | False    | N/A                                 | Download location of build wrapper/shell script        |
-| build_wrapper_out_dir | False    | N/A                                 | Local filesystem location of build artefacts           |
-| sonar_host_url        | False    | <https://sonarcloud.io>             | Uploads scans to the given host URL                    |
-| lc_all                | False    | en_US.UTF-8                         | Locale for code base (if not covered by en_US.UTF-8)   |
-| debug                 | False    | false                               | Enable debugging output                                |
-| project_base_dir      | False    | .                                   | Set the sonar.projectBaseDir analysis property         |
-| scanner_version       | False    | (uses SonarSource action's default) | Version of the Sonar Scanner CLI to use                |
-| args                  | False    | -Dsonar.scanner.cache.enabled=false | Arguments to pass to the Sonar Scanner CLI             |
+| Variable Name         | Required | Default                             | Description                                                              |
+| --------------------- | -------- | ----------------------------------- | ------------------------------------------------------------------------ |
+| sonar_token           | True     | N/A                                 | Mandatory authentication token to upload results                         |
+| sonar_root_cert       | False    | N/A                                 | PEM encoded server root certificate (for HTTPS upload)                   |
+| build_wrapper_url     | False    | N/A                                 | Download location of build wrapper/shell script                          |
+| build_wrapper_out_dir | False    | N/A                                 | Local filesystem location of build artefacts                             |
+| sonar_host_url        | False    | <https://sonarcloud.io>             | Uploads scans to the given host URL                                      |
+| lc_all                | False    | en_US.UTF-8                         | Locale for code base (if not covered by en_US.UTF-8)                     |
+| debug                 | False    | false                               | Enable debugging output                                                  |
+| project_base_dir      | False    | .                                   | Set the sonar.projectBaseDir analysis property                           |
+| scanner_version       | False    | (uses SonarSource action's default) | Version of the Sonar Scanner CLI to use                                  |
+| skip_jre_provisioning | False    | false                               | Skip JRE auto-provisioning by the Sonar Scanner CLI (see note below)     |
+| args                  | False    | -Dsonar.scanner.cache.enabled=false | Arguments to pass to the Sonar Scanner CLI                               |
 
 <!-- markdownlint-enable MD013 -->
+
+### Note: JRE auto-provisioning
+
+SonarSource is deprecating the bundled Java 17 runtime in the Sonar
+Scanner CLI; support ends July 2026. By default this action sets
+`skip_jre_provisioning=false`, allowing the scanner to download and
+run the JRE that SonarCloud / SonarQube requires. This keeps the
+runtime current automatically and silences the related analysis
+warning.
+
+Set `skip_jre_provisioning: 'true'` when network egress to the
+SonarSource binary host fails or air-gapped builds need to use the
+bundled JRE. See:
+
+<https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/scanner-environment/managing-jre-auto-provisioning/>
 
 ## Troubleshooting
 

--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,14 @@ inputs:
   scanner_version:
     description: 'Version of the Sonar Scanner CLI to use'
     required: false
+  skip_jre_provisioning:
+    # SonarSource is deprecating the bundled Java 17 runtime; support
+    # ends July 2026. Letting the scanner provision its own JRE keeps
+    # the runtime current automatically.
+    # See: https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/scanner-environment/managing-jre-auto-provisioning/
+    description: 'Skip JRE auto-provisioning by the Sonar Scanner CLI'
+    required: false
+    default: 'false'
   args:
     description: 'Arguments to pass to the Sonar Scanner CLI (e.g., "-Dsonar.verbose=true")'
     required: false
@@ -211,7 +219,7 @@ runs:
         SONAR_ROOT_CERT: ${{ inputs.sonar_root_cert }}
         SONAR_VERBOSE: ${{ inputs.debug }}
         LC_ALL: ${{ inputs.lc_all }}
-        SONAR_SCANNER_OPTS: "-Dsonar.scanner.skipJreProvisioning=true"
+        SONAR_SCANNER_OPTS: "-Dsonar.scanner.skipJreProvisioning=${{ inputs.skip_jre_provisioning }}"
       with:
         projectBaseDir: ${{ inputs.project_base_dir }}
         scannerVersion: ${{ inputs.scanner_version || '7.2.0.5079' }}


### PR DESCRIPTION
## Summary

Address the JRE deprecation warning emitted by recent SonarCloud
analyses:

> Java 17 scanner support in SonarQube Cloud ends in July 2026.
> Please upgrade to Java 21 or newer or use JRE auto-provisioning
> to keep this requirement always up to date.
> See: <https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/scanner-environment/managing-jre-auto-provisioning/>

The action previously hard-coded:

```yaml
SONAR_SCANNER_OPTS: "-Dsonar.scanner.skipJreProvisioning=true"
```

so consumers could not enable auto-provisioning without working
around the composite action's environment.

## Changes

### `action.yaml`

- New input **`skip_jre_provisioning`** (default `'false'`).
- `SONAR_SCANNER_OPTS` is now templated from the input value:

  ```yaml
  SONAR_SCANNER_OPTS: "-Dsonar.scanner.skipJreProvisioning=${{ inputs.skip_jre_provisioning }}"
  ```

### `README.md`

- New row in the inputs table.
- Short explanatory note covering the deprecation, the new
  default, and when to opt back into the bundled JRE
  (air-gapped / egress-restricted environments).

## Behaviour change

The default flips from effectively `true` to `false`. On the next
run after consumers pick up this version, the Sonar Scanner CLI
will download and cache the JRE that SonarCloud / SonarQube
requires (≈40 MB, cached by the scanner action between runs on
the same runner image).

For the vast majority of consumers using GitHub-hosted runners
with normal egress, this is the desired behaviour and silences
the deprecation warning automatically. Air-gapped or
egress-restricted environments can preserve the previous
behaviour by passing:

```yaml
with:
  skip_jre_provisioning: 'true'
```

## Verification

- `pre-commit` clean (yamllint, markdownlint, write-good,
  actionlint-where-applicable, reuse, codespell, etc.).
- Branch based on the latest `upstream/main` (no rebase needed).
- The existing testing workflow (`testing.yaml`) does not pass
  `skip_jre_provisioning` and will exercise the new default
  on first run, demonstrating that auto-provisioning works
  end-to-end against `test-python-project` and `rappmanager`.

## Downstream

After this lands and is tagged, the calling reusable workflow
(`lfit/releng-reusable-workflows/.github/workflows/reuse-sonarqube-cloud.yaml`)
should bump the action SHA. No new input is needed there unless
operators want to expose `skip_jre_provisioning` to consumers of
the reusable workflow as well.
